### PR TITLE
feat: add "always use ai task" toggle option

### DIFF
--- a/packages/core/src/components/features/settings/SettingsModal.tsx
+++ b/packages/core/src/components/features/settings/SettingsModal.tsx
@@ -282,6 +282,10 @@ const PreferencesSettings: React.FC = memo(() => {
         ...(p ?? defaultPreferencesFromAtoms),
         enableEcho: checked
     }));
+    const handleAlwaysUseAITaskToggle = (checked: boolean) => setPreferences(p => ({
+        ...(p ?? defaultPreferencesFromAtoms),
+        alwaysUseAITask: checked
+    }));
 
     const dueDateOptions = [
         {value: 'none', label: t('settings.preferences.dueDateOptions.none')},
@@ -363,6 +367,24 @@ const PreferencesSettings: React.FC = memo(() => {
                 >
                     <RadixSwitch.Thumb
                         className={twMerge("custom-switch-thumb", currentPreferences.enableEcho ? "custom-switch-thumb-on" : "custom-switch-thumb-off")}/>
+                </RadixSwitch.Root>
+            </SettingsRow>
+            <div className="h-px bg-grey-light dark:bg-neutral-700 my-0"></div>
+            <SettingsRow label={t('settings.preferences.alwaysUseAITask')}
+                         description={t('settings.preferences.alwaysUseAITaskDescription')}
+                         htmlFor="alwaysUseAITaskToggle">
+                <RadixSwitch.Root
+                    id="alwaysUseAITaskToggle"
+                    checked={currentPreferences.alwaysUseAITask}
+                    onCheckedChange={handleAlwaysUseAITaskToggle}
+                    aria-label="Toggle always use AI task"
+                    className={twMerge(
+                        "custom-switch-track",
+                        currentPreferences.alwaysUseAITask ? "custom-switch-track-on" : "custom-switch-track-off"
+                    )}
+                >
+                    <RadixSwitch.Thumb
+                        className={twMerge("custom-switch-thumb", currentPreferences.alwaysUseAITask ? "custom-switch-thumb-on" : "custom-switch-thumb-off")}/>
                 </RadixSwitch.Root>
             </SettingsRow>
         </div>

--- a/packages/core/src/components/features/tasks/TaskList.tsx
+++ b/packages/core/src/components/features/tasks/TaskList.tsx
@@ -204,6 +204,14 @@ const TaskList: React.FC<{ title: string }> = ({title: pageTitle}) => {
 
     }, [preferences, availableListsForNewTask, isLoadingPreferences]);
 
+    // Auto-enable AI task input when alwaysUseAITask is enabled and on the "all" page
+    useEffect(() => {
+        if (isLoadingPreferences) return;
+        if (preferences.alwaysUseAITask && currentFilterGlobal === 'all') {
+            setIsAiTaskInputVisible(true);
+        }
+    }, [preferences.alwaysUseAITask, currentFilterGlobal, isLoadingPreferences]);
+
     const {tasksToDisplay, isGroupedView, isSearching} = useMemo(() => {
         const searching = searchTerm.trim().length > 0;
         if (searching) {
@@ -565,7 +573,10 @@ const TaskList: React.FC<{ title: string }> = ({title: pageTitle}) => {
             addNotification({type: 'error', message: t('taskList.aiCreationError', {message: errorMessage})});
         } finally {
             setIsAiProcessing(false);
-            setIsAiTaskInputVisible(false);
+            // Keep AI task input visible if alwaysUseAITask is enabled
+            if (!preferences.alwaysUseAITask) {
+                setIsAiTaskInputVisible(false);
+            }
             if (isRegularNewTaskModeAllowed) {
                 setTimeout(() => newTaskTitleInputRef.current?.focus(), 0);
             }

--- a/packages/core/src/locales/en/translation.json
+++ b/packages/core/src/locales/en/translation.json
@@ -125,7 +125,9 @@
       "confirmDeletions": "Confirm Deletions",
       "confirmDeletionsDescription": "Show a confirmation dialog before moving tasks to trash.",
       "enableEcho": "Enable Echo",
-      "enableEchoDescription": "Enable the creative daily report generator."
+      "enableEchoDescription": "Enable the creative daily report generator.",
+      "alwaysUseAITask": "Always Use AI Task",
+      "alwaysUseAITaskDescription": "Automatically enable AI task input when opening the All Tasks page"
     },
     "ai": {
       "title": "AI Settings",

--- a/packages/core/src/locales/zh-CN/translation.json
+++ b/packages/core/src/locales/zh-CN/translation.json
@@ -125,7 +125,9 @@
       "confirmDeletions": "删除前确认",
       "confirmDeletionsDescription": "将任务移至垃圾桶前显示确认对话框。",
       "enableEcho": "启用回响",
-      "enableEchoDescription": "启用创意日报生成器。"
+      "enableEchoDescription": "启用创意日报生成器。",
+      "alwaysUseAITask": "始终使用 AI 任务",
+      "alwaysUseAITaskDescription": "打开「所有任务」页面时自动启用 AI 任务输入"
     },
     "ai": {
       "title": "AI 设置",

--- a/packages/core/src/store/jotai.ts
+++ b/packages/core/src/store/jotai.ts
@@ -64,7 +64,7 @@ export const defaultAppearanceSettingsForApi = (): AppearanceSettings => ({
 export const defaultPreferencesSettingsForApi = (): PreferencesSettings => ({
     language: 'zh-CN', defaultNewTaskDueDate: null, defaultNewTaskPriority: null,
     defaultNewTaskList: 'Inbox', confirmDeletions: true, zenModeShyNative: false,
-    enableEcho: true, echoJobTypes: [], echoPastExamples: ''
+    enableEcho: true, echoJobTypes: [], echoPastExamples: '', alwaysUseAITask: false
 });
 export const defaultAISettingsForApi = (): AISettings => ({
     provider: 'openai',

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -128,6 +128,7 @@ export interface PreferencesSettings {
     enableEcho: boolean; // Toggle for the Echo feature
     echoJobTypes: string[]; // Selected job types for Echo
     echoPastExamples?: string; // User provided past report examples
+    alwaysUseAITask: boolean; // Toggle for always using AI task input
 }
 
 /**


### PR DESCRIPTION
因为在使用过程中，更倾向于让 ai 自己处理时间和优先级，但是现在的行为是，提交一次任务以后，AI 任务的选项会被自动关闭，所以做了一点修改

加了一个“始终使用 AI 任务”的选项
<img width="1011" height="554" alt="image" src="https://github.com/user-attachments/assets/b76bc19d-bfe7-4c1d-b05c-e4e0a0808997" />
启用以后，进入任务页面或者是提交完任务以后，AI 任务都会始终开启

