### PR TITLE
fix: resolve wrong ollama endpoint and json parsing issue

### DIFF
--- a/packages/core/src/config/aiProviders.ts
+++ b/packages/core/src/config/aiProviders.ts
@@ -276,7 +276,7 @@ export const AI_PROVIDERS: AIProvider[] = [
         requiresApiKey: false,
         requiresBaseUrl: true,
         defaultBaseUrl: 'http://localhost:11434',
-        apiEndpoint: '/v1/chat/completions', // Assuming OpenAI compatibility
+        apiEndpoint: '/api/chat',
         listModelsEndpoint: '/api/tags',
         getHeaders: () => ({ 'Content-Type': 'application/json' }),
         parseModels: (data) => data.models.map((m: any) => ({

--- a/packages/core/src/services/aiService.ts
+++ b/packages/core/src/services/aiService.ts
@@ -128,7 +128,7 @@ export const testConnection = async (settings: AISettings): Promise<boolean> => 
             payload = provider.requestBodyTransformer(payload);
         }
 
-        const endpoint = provider.id === 'ollama' ? `${getApiEndpoint(settings, 'chat')}/api/chat` : getApiEndpoint(settings, 'chat');
+        const endpoint = getApiEndpoint(settings, 'chat');
 
         const response = await fetch(endpoint, {
             method: 'POST',
@@ -189,7 +189,7 @@ export const analyzeTaskInputWithAI = async (prompt: string, settings: AISetting
         payload = provider.requestBodyTransformer(payload);
     }
 
-    const endpoint = provider.id === 'ollama' ? `${getApiEndpoint(settings, 'chat')}/api/chat` : getApiEndpoint(settings, 'chat');
+    const endpoint = getApiEndpoint(settings, 'chat');
 
     try {
         const response = await fetch(endpoint, {
@@ -204,7 +204,13 @@ export const analyzeTaskInputWithAI = async (prompt: string, settings: AISetting
 
         const data = await response.json();
         const content = extractContentFromResponse(data, provider.id);
-        const cleanedContent = content.replace(/^```json\s*|```\s*$/g, '').trim();
+        // Remove markdown code blocks and extract JSON object
+        let cleanedContent = content.replace(/^```json\s*|```\s*$/g, '').trim();
+        // Try to extract JSON object if content contains non-JSON text
+        const jsonMatch = cleanedContent.match(/\{[\s\S]*\}/);
+        if (jsonMatch) {
+            cleanedContent = jsonMatch[0];
+        }
         return JSON.parse(cleanedContent) as AiTaskAnalysis;
     } catch (error) {
         console.error("AI Task analysis failed:", error);
@@ -272,7 +278,7 @@ export const streamChatCompletionForEditor = async (
         payload = provider.requestBodyTransformer(payload);
     }
 
-    const endpoint = provider.id === 'ollama' ? `${getApiEndpoint(settings, 'chat')}/api/chat` : getApiEndpoint(settings, 'chat');
+    const endpoint = getApiEndpoint(settings, 'chat');
 
     const response = await fetch(endpoint, {
         method: 'POST',


### PR DESCRIPTION
- use native api endpoint instead of openai-compatible
- improve json extraction to handle non-json text(or think block)

原有代码中尝试使用 openai 兼容的 uri，并且拼接逻辑存在问题，现在改用 ollama 原生 uri

发现使用 ollama模型的时候会报错`JSON Parse error: Unrecognized token '<'`，怀疑是 think 的原因。现在加上了 json 的提取